### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@4.1.6
+      with:
+        branch: gh-pages
+        folder: src


### PR DESCRIPTION
Use GitHub for hosting, retire https://berlin.codefor.de/trinkwasser and use https://trinkwasser.berlin.codefor.de.